### PR TITLE
Don't crash when updating devices with which connection has been lost.

### DIFF
--- a/plugins/Wiser/plugin.py
+++ b/plugins/Wiser/plugin.py
@@ -186,19 +186,16 @@ class BasePlugin:
             Unit = self.Units[ str(4096 + Room['id']) ]
             Devices[Unit].Update(nValue=0, sValue=sValue, TimedOut=0)
 
-
-
-
-
     def updateHotWater(self, WaterInfo):
         Unit = self.Units[ str(512 + WaterInfo['id']) ]
-
-        if WaterInfo['WaterHeatingState'] == "On":
+        
+        state = WaterInfo.get("WaterHeatingState", "Unknown")
+        if state == "On":
             nValue = 1
-        elif WaterInfo['WaterHeatingState'] == "Off":
+        elif state == "Off":
             nValue = 0
         else:
-            Domoticz.Log("WaterHeatingState '%s' for device %d is unrecognised, skipping device." % (WaterInfo['WaterHeatingState'], Devices[Unit].ID))
+            Domoticz.Log("WaterHeatingState '%s' for device %d is unrecognised, skipping device." % (state, Devices[Unit].ID))
             return
 
         if Devices[Unit].nValue != nValue:
@@ -206,16 +203,16 @@ class BasePlugin:
         else:
             Devices[Unit].Touch()
 
-
     def updateSmartPlug(self, Plug):
         Unit = self.Units[ str(1024 + Plug['id']) ]
-
-        if Plug['OutputState'] == "On":
+        
+        state = Plug.get("OutputState", "Unknown")
+        if state == "On":
             nValue = 1
-        elif Plug['OutputState'] == "Off":
+        elif state == "Off":
             nValue = 0
         else:
-            Domoticz.Log("SmartPlug state '%s' for device %d is unrecognised, skipping device." % (Plug['OutputState'], Devices[Unit].ID))
+            Domoticz.Log("SmartPlug state '%s' for device %d is unrecognised, skipping device." % (state, Devices[Unit].ID))
             return
 
         if Devices[Unit].nValue != nValue:
@@ -226,12 +223,13 @@ class BasePlugin:
     def updateBoiler(self, Boiler):
         Unit = self.Units[ str(2048 + Boiler['id']) ]
 
-        if Boiler['HeatingRelayState'] == "On":
+        state = Boiler.get("HeatingRelayState", "Unknown")
+        if state == "On":
             nValue = 1
-        elif Boiler['HeatingRelayState'] == "Off":
+        elif state == "Off":
             nValue = 0
         else:
-            Domoticz.Log("HeatingChannel state '%s' for device %d is unrecognised, skipping device." % (Boiler['OutputState'], Devices[Unit].ID))
+            Domoticz.Log("HeatingChannel state '%s' for device %d is unrecognised, skipping device." % (state, Devices[Unit].ID))
             return
 
         if Devices[Unit].nValue != nValue:


### PR DESCRIPTION
It seems that the Wiser hub returns JSON containing different property names for a device if it's lost it's connection to that device.

Specifically, for me, I had a SmartPlug device which had lost its connection to the hub. The hub reported the plug's status without an "OutputState" property, but with a property called "ManualState" instead.

This commit makes the plugin more resilient to the expected property name being missing.